### PR TITLE
Swap order of explosion to fix compatibility with gravestone mods

### DIFF
--- a/src/main/java/com/kryptography/explodingfurnaces/event/Boom.java
+++ b/src/main/java/com/kryptography/explodingfurnaces/event/Boom.java
@@ -22,8 +22,8 @@ public class Boom {
             IItemHandler inventory = new PlayerMainInvWrapper(player.getInventory());
             for (int i = 0; i < inventory.getSlots(); i++)
                 if(inventory.getStackInSlot(i).getItem() == ItemInit.HOT_GUNPOWDER.get()) {
-                    level.explode(null, player.getX(), player.getY(), player.getZ(), 4.0F, Level.ExplosionInteraction.TNT);
                     inventory.extractItem(i, inventory.getSlotLimit(i), false);
+                    level.explode(null, player.getX(), player.getY(), player.getZ(), 4.0F, Level.ExplosionInteraction.TNT);
                 }
         }
     }


### PR DESCRIPTION
With how it was before, the mod would kill you, but not take away the exploding gunpowder until after you died. This is fine in vanilla gameplay, but in modded scenarios, the exploding gunpowder would be added to a player's gravestone/tombstone. This would then essentially lock the player out of their items, since whenever they would pick up their items, it would include the gunpowder, which would kill them again.

My change swaps the order of operations so that the mod works properly with these kinds of mods.